### PR TITLE
Don't send all logs when containers start/restart

### DIFF
--- a/router/pump.go
+++ b/router/pump.go
@@ -109,7 +109,7 @@ func (p *LogsPump) Run() error {
 		debug("pump: event:", normalID(event.ID), event.Status)
 		switch event.Status {
 		case "start", "restart":
-			go p.pumpLogs(event, true)
+			go p.pumpLogs(event, false)
 		case "die":
 			go p.update(event)
 		}


### PR DESCRIPTION
- This is to prevent log spam when log running containers get a restart
