### PR TITLE
Print log message for each processed event to stdout.

### DIFF
--- a/router/pump.go
+++ b/router/pump.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/fsouza/go-dockerclient"
+	"fmt"
 )
 
 func init() {
@@ -107,6 +108,13 @@ func (p *LogsPump) Run() error {
 	}
 	for event := range events {
 		debug("pump: event:", normalID(event.ID), event.Status)
+
+		// Print log message to be sent to Kafka. Logspout picks up STDOUT
+		// from all containers that have "LOGSPOUT=true" enabled at runtime.
+		logMessage := fmt.Sprintf("{\"timestamp\": \"%s\", \"type\": \"%s\", \"action\": \"%s\", \"from\": \"%s\", \"id\": \"%s\"",
+					  time.Now().Format(time.RFC3339), event.Type, event.Action, event.From, event.Actor.ID)
+		fmt.Println(logMessage)
+
 		switch event.Status {
 		case "start", "restart":
 			go p.pumpLogs(event, false)


### PR DESCRIPTION
This change is meant to work with logspout container been launched with environment variable "LOGSPOUT" as true.

This change prints logspout events to STDOUT, which are picked up by Logspout itself and sent to Kafka. It outputs a json formatted string, which will be inserted inside Kafka template.

For details of fields see: https://github.com/fsouza/go-dockerclient/blob/366d38beae4ef61bcf52b53e0fc1eeef03c9aa04/event.go#L33-L53
## JIRA

https://duedil.atlassian.net/browse/DD-7534
